### PR TITLE
japanese.flagを立てる部分を移動し、各文献形式のフォーマットを簡素化

### DIFF
--- a/IEEEtranS_withJP.bst
+++ b/IEEEtranS_withJP.bst
@@ -728,6 +728,9 @@ FUNCTION {fin.entry}
   if$
   write$
   newline$
+  %% for JP setting
+  #0 'japanese.flag :=
+  default.name.format.string 'name.format.string :=
 }
 
 
@@ -1077,6 +1080,19 @@ FUNCTION {convert.edition}
 
 
 
+%%%%%%%%%%%%%%%%%%%%%%
+%% JAPANESE CHECKER %%
+%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION {chk.jp.entry} {
+  isjapanese empty$ 
+    {skip$} 
+    {#1 'japanese.flag :=
+    default.name.format.string.forJP 'name.format.string :=} 
+  if$
+}
+
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% LATEX BIBLIOGRAPHY CODE %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1089,6 +1105,7 @@ FUNCTION {start.entry}
   newline$
   ""
   initialize.prev.this.status
+  chk.jp.entry
 }
 
 % Here we write out all the LaTeX code that we will need. The most involved
@@ -2037,13 +2054,6 @@ FUNCTION {format.url}
 FUNCTION {article}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=} 
- if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors "author" output.warn
   name.or.dash
@@ -2057,22 +2067,11 @@ FUNCTION {article}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {book}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
- if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   author empty$
     { format.editors "author and editor" output.warn }
@@ -2092,22 +2091,11 @@ FUNCTION {book}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {booklet}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
- if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors output
   name.or.dash
@@ -2120,22 +2108,11 @@ FUNCTION {booklet}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {electronic}
 { std.status.using.period
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
- if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors output
   name.or.dash
@@ -2149,22 +2126,11 @@ FUNCTION {electronic}
   fin.entry
   empty.entry.warn
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {inbook}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
- if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   author empty$
     { format.editors "author and editor" output.warn }
@@ -2182,22 +2148,11 @@ FUNCTION {inbook}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {incollection}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
- if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors "author" output.warn
   name.or.dash
@@ -2214,22 +2169,11 @@ FUNCTION {incollection}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {inproceedings}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
- if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors "author" output.warn
   name.or.dash
@@ -2251,22 +2195,11 @@ FUNCTION {inproceedings}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {manual}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
- if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors output
   name.or.dash
@@ -2279,21 +2212,11 @@ FUNCTION {manual}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {mastersthesis}
 { std.status.using.comma
   start.entry
-    %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-    {skip$}
-    {#1 'japanese.flag :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors "author" output.warn
   name.or.dash
@@ -2306,22 +2229,12 @@ FUNCTION {mastersthesis}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {misc}
 { 
   std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-    {skip$}
-    {#1 'japanese.flag :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors output
   name.or.dash
@@ -2336,21 +2249,11 @@ FUNCTION {misc}
   fin.entry
   empty.entry.warn
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {patent}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-    {skip$}
-    {#1 'japanese.flag :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors output
   name.or.dash
@@ -2362,21 +2265,11 @@ FUNCTION {patent}
   fin.entry
   empty.entry.warn
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {periodical}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-    {skip$}
-    {#1 'japanese.flag :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.editors output
   name.or.dash
@@ -2390,22 +2283,11 @@ FUNCTION {periodical}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {phdthesis}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-    {skip$}
-    {#1 'japanese.flag :=
-    default.name.format.string.forJP 'name.format.string :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors "author" output.warn
   name.or.dash
@@ -2418,22 +2300,11 @@ FUNCTION {phdthesis}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {proceedings}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
- if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.editors output
   name.or.dash
@@ -2451,22 +2322,11 @@ FUNCTION {proceedings}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {standard}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
- if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors output
   name.or.dash
@@ -2479,22 +2339,11 @@ FUNCTION {standard}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {techreport}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
- if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors "author" output.warn
   name.or.dash
@@ -2508,22 +2357,11 @@ FUNCTION {techreport}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {unpublished}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
- if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors "author" output.warn
   name.or.dash
@@ -2533,10 +2371,6 @@ FUNCTION {unpublished}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 

--- a/IEEEtran_withJP.bst
+++ b/IEEEtran_withJP.bst
@@ -714,12 +714,15 @@ FUNCTION {fin.entry}
       if$
     }
   if$
-   this.status.quote quote.close =
-     { "''" * }
-     { skip$ }
-   if$
-write$
-newline$
+  this.status.quote quote.close =
+    { "''" * }
+    { skip$ }
+  if$
+  write$
+  newline$
+  %% for JP setting
+  #0 'japanese.flag :=
+  default.name.format.string 'name.format.string :=
 }
 
 
@@ -1067,6 +1070,17 @@ FUNCTION {convert.edition}
 }
 
 
+%%%%%%%%%%%%%%%%%%%%%%
+%% JAPANESE CHECKER %%
+%%%%%%%%%%%%%%%%%%%%%%
+
+FUNCTION {chk.jp.entry} {
+  isjapanese empty$ 
+    {skip$} 
+    {#1 'japanese.flag :=
+    default.name.format.string.forJP 'name.format.string :=} 
+  if$
+}
 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -1081,6 +1095,7 @@ FUNCTION {start.entry}
   newline$
   ""
   initialize.prev.this.status
+  chk.jp.entry
 }
 
 % Here we write out all the LaTeX code that we will need. The most involved
@@ -1191,7 +1206,6 @@ FUNCTION {longest.label.pass}
     }
   if$
 }
-
 
 
 
@@ -2031,13 +2045,6 @@ FUNCTION {format.url}
 FUNCTION {article}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=} 
-  if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors "author" output.warn
   name.or.dash
@@ -2051,22 +2058,11 @@ FUNCTION {article}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {book}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
-  if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   author empty$
     { format.editors "author and editor" output.warn }
@@ -2086,22 +2082,11 @@ FUNCTION {book}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {booklet}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
-  if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors output
   name.or.dash
@@ -2114,22 +2099,11 @@ FUNCTION {booklet}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {electronic}
 { std.status.using.period
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
-  if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors output
   name.or.dash
@@ -2143,22 +2117,11 @@ FUNCTION {electronic}
   fin.entry
   empty.entry.warn
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {inbook}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
-  if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   author empty$
     { format.editors "author and editor" output.warn }
@@ -2176,22 +2139,11 @@ FUNCTION {inbook}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {incollection}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
-  if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors "author" output.warn
   name.or.dash
@@ -2208,22 +2160,11 @@ FUNCTION {incollection}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {inproceedings}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$ 
-   {skip$} 
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
-  if$ 
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors "author" output.warn
   name.or.dash
@@ -2245,22 +2186,11 @@ FUNCTION {inproceedings}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {manual}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-   {skip$}
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors output
   name.or.dash
@@ -2273,21 +2203,11 @@ FUNCTION {manual}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {mastersthesis}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-   {skip$}
-   {#1 'japanese.flag :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors "author" output.warn
   name.or.dash
@@ -2300,21 +2220,11 @@ FUNCTION {mastersthesis}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {misc}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-   {skip$}
-   {#1 'japanese.flag :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors output
   name.or.dash
@@ -2329,21 +2239,11 @@ FUNCTION {misc}
   fin.entry
   empty.entry.warn
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {patent}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-   {skip$}
-   {#1 'japanese.flag :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors output
   name.or.dash
@@ -2355,21 +2255,11 @@ FUNCTION {patent}
   fin.entry
   empty.entry.warn
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {periodical}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-   {skip$}
-   {#1 'japanese.flag :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.editors output
   name.or.dash
@@ -2383,22 +2273,11 @@ FUNCTION {periodical}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {phdthesis}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-   {skip$}
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors "author" output.warn
   name.or.dash
@@ -2411,22 +2290,11 @@ FUNCTION {phdthesis}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {proceedings}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-   {skip$}
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.editors output
   name.or.dash
@@ -2444,22 +2312,11 @@ FUNCTION {proceedings}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {standard}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-   {skip$}
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors output
   name.or.dash
@@ -2472,22 +2329,11 @@ FUNCTION {standard}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {techreport}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-   {skip$}
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors "author" output.warn
   name.or.dash
@@ -2501,22 +2347,11 @@ FUNCTION {techreport}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 FUNCTION {unpublished}
 { std.status.using.comma
   start.entry
-  %%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-  isjapanese empty$
-   {skip$}
-   {#1 'japanese.flag :=
-   default.name.format.string.forJP 'name.format.string :=}
-  if$
-  %%変更箇所1ここまで
   if.url.alt.interword.spacing
   format.authors "author" output.warn
   name.or.dash
@@ -2526,10 +2361,6 @@ FUNCTION {unpublished}
   format.url output
   fin.entry
   if.url.std.interword.spacing
-  %%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-  #0 'japanese.flag :=
-  default.name.format.string 'name.format.string :=
-  %%変更箇所2ここまで
 }
 
 

--- a/README.md
+++ b/README.md
@@ -99,17 +99,17 @@ FUNCTION {default.name.format.string.forJP}{ "{ff~}{vv~}{ll}{, jj}" } %%追加�
 ```bst
 FUNCTION {initialize.controls}
 { default.is.use.number.for.article 'is.use.number.for.article :=
-default.is.use.paper 'is.use.paper :=
-default.is.use.url 'is.use.url :=
-default.is.forced.et.al 'is.forced.et.al :=
-default.max.num.names.before.forced.et.al 'max.num.names.before.forced.et.al :=
-default.num.names.shown.with.forced.et.al 'num.names.shown.with.forced.et.al :=
-default.is.use.alt.interword.spacing 'is.use.alt.interword.spacing :=
-default.is.dash.repeated.names 'is.dash.repeated.names :=
-default.ALTinterwordstretchfactor 'ALTinterwordstretchfactor :=
-default.name.format.string 'name.format.string := %%ここで代入されている
-default.name.latex.cmd 'name.latex.cmd :=
-default.name.url.prefix 'name.url.prefix :=
+  default.is.use.paper 'is.use.paper :=
+  default.is.use.url 'is.use.url :=
+  default.is.forced.et.al 'is.forced.et.al :=
+  default.max.num.names.before.forced.et.al 'max.num.names.before.forced.et.al :=
+  default.num.names.shown.with.forced.et.al 'num.names.shown.with.forced.et.al :=
+  default.is.use.alt.interword.spacing 'is.use.alt.interword.spacing :=
+  default.is.dash.repeated.names 'is.dash.repeated.names :=
+  default.ALTinterwordstretchfactor 'ALTinterwordstretchfactor :=
+  default.name.format.string 'name.format.string := %%ここで代入されている
+  default.name.latex.cmd 'name.latex.cmd :=
+  default.name.url.prefix 'name.url.prefix :=
 }
 ```
 
@@ -132,44 +132,12 @@ default.name.url.prefix 'name.url.prefix :=
 ## 日本語文献の複数著者の場合に出てきてしまうandの抑制
 `FUNCTION{format.names}`の変更。
 
-## 全ての文献形式にフラグを管理する処理を追加 + 日本語
+## start.entry及びfin.entryに日本語フラグを管理する処理を追加
 bibにisjapaneseが{true}で入っていた場合に`japanese.flag`を立てる処理をします。
 また，先程述べた日本語と英語での書式の変更もここでやってしまいます。
 
 
-- `isjapanese`を探して`japanese.flag`を立てる。
+- `start.entry`内にて`isjapanese`を探して`japanese.flag`を立てる。
 - flagが1の時，日本語用の名前フォーマット`default.name.format.string.forJP`へと`name.format.string`を切り替える。
-- 最後に`japanese.flag`を0に戻して，名前のフォーマットを英語用に戻す。
+- 最後に`fin.entry`内で`japanese.flag`を0に戻して，名前のフォーマットを英語用に戻す。
 
-```
-FUNCTION {article}
-{ std.status.using.comma
-start.entry
-%%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
-isjapanese empty$ 
-{skip$} 
-{#1 'japanese.flag :=
-default.name.format.string.forJP 'name.format.string :=} 
-if$ 
-%%変更箇所1ここまで
-if.url.alt.interword.spacing
-format.authors "author" output.warn
-name.or.dash
-format.article.title "title" output.warn
-format.journal "journal" bibinfo.check "journal" output.warn
-format.volume output
-format.number.if.use.for.article output
-format.pages output
-format.date "year" output.warn
-format.note output
-format.url output
-fin.entry
-if.url.std.interword.spacing
-%%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
-#0 'japanese.flag :=
-default.name.format.string 'name.format.string :=
-%%変更箇所2ここまで
-}
-```
-
-これを`article`だけでなく全ての文章タイプに対して適用した。


### PR DESCRIPTION
各文献形式に
```
%%変更箇所1：日本語エントリに何かあれば日本語化するフラグを立てる
isjapanese empty$ 
{skip$} 
{#1 'japanese.flag :=
default.name.format.string.forJP 'name.format.string :=} 
if$ 
%%変更箇所1ここまで
```
と
```
%%変更箇所2：次の文献のために日本語化フラグの解除(0に戻しておく)
#0 'japanese.flag :=
default.name.format.string 'name.format.string :=
%%変更箇所2ここまで
```
が記載されていますが、`start.entry`及び`fin.entry`に移すことで簡略化できました。
合わせて、日本語ファイルかのチェック部分を
```
FUNCTION {chk.jp.entry} {
  isjapanese empty$ 
    {skip$} 
    {#1 'japanese.flag :=
    default.name.format.string.forJP 'name.format.string :=} 
  if$
}
```
と、関数化しました。`README.md`も修正・フォーマット調整をしました。