### PR TITLE
bugfix: a comma is needed at the line end

### DIFF
--- a/bibFileGenerator_python/addJPflag.py
+++ b/bibFileGenerator_python/addJPflag.py
@@ -74,6 +74,8 @@ if __name__ == '__main__':
                 if re.match(r'\s*author', line):
                     line = format_jp_authors(line)                    
                 if not jpflag:
+                    if line[-1] != ',':
+                        line += ','
                     line += '\n' + ' '*nspace + 'isjapanese = {true},'
                     jpflag = True
             output += line + '\n'


### PR DESCRIPTION
私が書いたコードにバグがありました。
エントリ末尾のキーで日本語だと判定された場合に、カンマが抜けることでコンパイル時にエラーが吐かれておりました。