### PR TITLE
addjp.pyにおけるチルダの挿入の廃止

### DIFF
--- a/addjp.py
+++ b/addjp.py
@@ -37,7 +37,7 @@ def chk_last_comma(line):
 
 
 def format_jp_keys(line, skip=False):
-    line = format_authors(line)
+    # line = format_authors(line)
     if not skip:
         nspace = re.match(r'\s*', line).end()
         prefix = '\n' if chk_last_comma(line) else ',\n'

--- a/test/jsamplebib.bib
+++ b/test/jsamplebib.bib
@@ -1,5 +1,5 @@
 @article{japaneseTest1,
- author = {山田~一郎 and 山田~次郎 and 山田~三郎 and 山田~四郎},
+ author = {山田 一郎 and 山田 次郎 and 山田 三郎 and 山田 四郎},
  isjapanese = {true},
  year = {2019},
  journal = {日本語学会},
@@ -9,7 +9,7 @@
  volume = {15}
 }
 @article{japaneseTest2,
- author = {山田~五郎 and 山田~六郎},
+ author = {山田 五郎 and 山田 六郎},
  isjapanese = {true},
  year = {2019},
  journal = {日本語学会},
@@ -19,7 +19,7 @@
  volume = {15}
 }
 @book{japaneseBook1,
- author = {佐藤~一郎},
+ author = {佐藤 一郎},
  isjapanese = {true},
  year = {2010},
  publisher = {日本語出版},
@@ -29,7 +29,7 @@
  pages = {100--200}
 }
 @book{japaneseBook2,
- author = {佐藤~二郎 and 佐藤~三郎},
+ author = {佐藤 二郎 and 佐藤 三郎},
  isjapanese = {true},
  year = {2012},
  publisher = {日本語出版},
@@ -39,7 +39,7 @@
  pages = {100--200}
 }
 @incollection{japaneseBook3,
- author = {佐藤~二郎 and 佐藤~三郎},
+ author = {佐藤 二郎 and 佐藤 三郎},
  isjapanese = {true},
  year = {2012},
  publisher = {日本語出版},


### PR DESCRIPTION
#32 で指摘されたように、bibファイルで姓名間にチルダを入れても意味がありませんでした。
addjp.pyにおいてチルダを入れる処理を停止しました。コードは残しています。