### PR TITLE
howtouse.texのuplatex対応・日本語LaTeXの新常識2021対応

### DIFF
--- a/howtouse.tex
+++ b/howtouse.tex
@@ -1,4 +1,6 @@
-\documentclass[10pt, a4paper]{jsarticle}
+\RequirePackage{plautopatch}
+\documentclass[10pt, a4paper, dvipdfmx, platex]{jsarticle} % for platex
+% \documentclass[10pt, a4paper, dvipdfmx, uplatex]{jsarticle} % for uplatex
 \usepackage[top=20truemm, bottom=20truemm, left=25truemm, right=25truemm]{geometry}
 \setlength{\columnsep}{3zw}
 \usepackage{listings, jlisting}


### PR DESCRIPTION
`howtouse.tex` に対して以下の変更を加えます。
* uplatexでコンパイルできるようにする
* [日本語LaTeXの新常識2021](https://qiita.com/wtsnjp/items/76557b1598445a1fc9da)で推奨されている記述適用